### PR TITLE
Fix segfault without --alter flag

### DIFF
--- a/bin/pg_migrate.c
+++ b/bin/pg_migrate.c
@@ -1545,11 +1545,9 @@ migrate_one_table(migrate_table *table, const char *orderby, char *errbuf, size_
 	elog(DEBUG2, "---- create temp table ----");
 	command(create_table, 0, NULL);
 
-	if (alter_list.head != NULL)
-	{
-		if (!(apply_alter_statement(connection, table->target_oid, alter_list.head->val)))
-			goto cleanup;
-	}
+	if (alter_list.head != NULL &&
+		!(apply_alter_statement(connection, table->target_oid, alter_list.head->val)))
+		goto cleanup;
 
 	/* apply alter column statemnts (if any) */
 	resetStringInfo(&sql);

--- a/bin/pg_migrate.c
+++ b/bin/pg_migrate.c
@@ -1545,8 +1545,11 @@ migrate_one_table(migrate_table *table, const char *orderby, char *errbuf, size_
 	elog(DEBUG2, "---- create temp table ----");
 	command(create_table, 0, NULL);
 
-	if (!(apply_alter_statement(connection, table->target_oid, alter_list.head->val)))
-		goto cleanup;
+	if (alter_list.head != NULL)
+	{
+		if (!(apply_alter_statement(connection, table->target_oid, alter_list.head->val)))
+			goto cleanup;
+	}
 
 	/* apply alter column statemnts (if any) */
 	resetStringInfo(&sql);


### PR DESCRIPTION
Summary
Fix NULL pointer dereference when --alter flag is not provided: alter_list.head was dereferenced without a NULL check in pg_migrate_rebuild_table(), causing a segfault when running pg_migrate --execute without -a.

Test case:
CREATE TABLE no_alter_ts_test (id integer PRIMARY KEY, val text);
INSERT INTO no_alter_ts_test VALUES (1, 'x');
pg_migrate --dbname=contrib_regression --table=no_alter_ts_test --tablespace=pg_default --execute